### PR TITLE
fix: handle unmapped HTTP statuses without crashing UPnP discovery (#232)

### DIFF
--- a/yaacc/src/main/java/de/yaacc/upnp/protocol/async/RetrieveRemoteDescriptors.java
+++ b/yaacc/src/main/java/de/yaacc/upnp/protocol/async/RetrieveRemoteDescriptors.java
@@ -163,6 +163,16 @@ public class RetrieveRemoteDescriptors implements Runnable {
                             + rd.getIdentity().getDescriptorURL()
                             + " ,exception on send: ", ex);
             return;
+        } catch (RuntimeException ex) {
+            // Defence in depth: a single misbehaving device on the LAN must never be allowed
+            // to kill the discovery worker thread. The cling library has multiple throw sites
+            // for runtime exceptions (e.g. IllegalStateException for unmapped HTTP statuses,
+            // see issue #232 / PR #221 #219) - swallow them all at the worker boundary.
+            YaaccLogger.w(getClass().getName(),
+                    "Device descriptor retrieval failed: "
+                            + rd.getIdentity().getDescriptorURL()
+                            + " ,unexpected runtime exception: ", ex);
+            return;
         }
 
 

--- a/yaacc/src/main/java/de/yaacc/upnp/server/http/HttpRequestSender.java
+++ b/yaacc/src/main/java/de/yaacc/upnp/server/http/HttpRequestSender.java
@@ -49,7 +49,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import de.yaacc.util.YaaccLogger;
@@ -127,16 +126,23 @@ public class HttpRequestSender {
 
 
     protected StreamResponseMessage createResponse(ClassicHttpResponse response) throws IOException {
-        // Status
-        if (UpnpResponse.Status.getByStatusCode(response.getCode()) == null) {
-            throw new IllegalStateException("can't create UpnpResponse.Status from http response status: " + response.getCode());
-        }
         YaaccLogger.d(getClass().getName(), "Received response code: " + response.getCode());
-        UpnpResponse responseOperation =
-                new UpnpResponse(
-                        response.getCode(),
-                        Objects.requireNonNull(UpnpResponse.Status.getByStatusCode(response.getCode())).getStatusMsg()
-                );
+        UpnpResponse.Status mappedStatus = UpnpResponse.Status.getByStatusCode(response.getCode());
+        UpnpResponse responseOperation;
+        if (mappedStatus != null) {
+            responseOperation = new UpnpResponse(response.getCode(), mappedStatus.getStatusMsg());
+        } else {
+            // Some real-world UPnP devices return HTTP statuses outside the small canonical
+            // UpnpResponse.Status enum (e.g. Sky Q DVRs return 401 on description fetches by
+            // design - see issue #232). Synthesize a generic failed UpnpResponse instead of
+            // throwing - the caller path (RetrieveRemoteDescriptors.describe) already treats
+            // isFailed() responses as a per-device skip, so unmapped statuses flow through
+            // the same skip path.
+            YaaccLogger.w(getClass().getName(),
+                    "Unmapped HTTP status " + response.getCode()
+                            + " from upstream UPnP device - treating as non-UPnP failure response, skipping device");
+            responseOperation = new UpnpResponse(response.getCode(), "HTTP " + response.getCode());
+        }
         YaaccLogger.d(getClass().getName(), "Received response: " + responseOperation);
         StreamResponseMessage responseMessage = new StreamResponseMessage(responseOperation);
         // Headers

--- a/yaacc/src/test/java/de/yaacc/upnp/server/http/HttpRequestSenderTest.java
+++ b/yaacc/src/test/java/de/yaacc/upnp/server/http/HttpRequestSenderTest.java
@@ -1,8 +1,35 @@
+/*
+ *
+ * Copyright (C) 2026 Tobias Schoene www.yaacc.de
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
 package de.yaacc.upnp.server.http;
 
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
+import org.fourthline.cling.model.message.StreamResponseMessage;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class HttpRequestSenderTest {
 
@@ -17,5 +44,71 @@ public class HttpRequestSenderTest {
         // Test that HTTP request sender can be instantiated
         HttpRequestSender httpRequestSender = new HttpRequestSender();
         assertNotNull(httpRequestSender);
+    }
+
+    /**
+     * Happy path: an HTTP 200 response is mapped to a successful UpnpResponse
+     * with the canonical "OK" status message.
+     */
+    @Test
+    public void testCreateResponse_200_mapsToOk() throws Exception {
+        StreamResponseMessage msg = new HttpRequestSender().createResponse(buildResponse(200, "<root/>"));
+        assertNotNull(msg);
+        assertEquals(200, msg.getOperation().getStatusCode());
+        assertEquals("OK", msg.getOperation().getStatusMessage());
+        assertFalse(msg.getOperation().isFailed());
+    }
+
+    /**
+     * Regression for issue #232. A 401 (e.g. Sky Q DVR's authenticated UPnP
+     * service) used to throw IllegalStateException out of createResponse and
+     * crash the discovery worker. It must now produce a synthetic failed
+     * UpnpResponse so the caller can skip the device.
+     */
+    @Test
+    public void testCreateResponse_401_doesNotThrow() throws Exception {
+        StreamResponseMessage msg = new HttpRequestSender().createResponse(buildResponse(401, "Unauthorized"));
+        assertNotNull(msg);
+        assertEquals(401, msg.getOperation().getStatusCode());
+        assertEquals("HTTP 401", msg.getOperation().getStatusMessage());
+        assertTrue("401 must report isFailed() so the discovery loop skips the device",
+                msg.getOperation().isFailed());
+    }
+
+    /**
+     * Regression for issue #219 / PR #221. 503 was added to the canonical
+     * Status enum in that PR; verify it still maps to the canonical
+     * "Service Unavailable" message rather than the synthetic fallback.
+     */
+    @Test
+    public void testCreateResponse_503_mapsToServiceUnavailable() throws Exception {
+        StreamResponseMessage msg = new HttpRequestSender().createResponse(buildResponse(503, ""));
+        assertNotNull(msg);
+        assertEquals(503, msg.getOperation().getStatusCode());
+        assertEquals("Service Unavailable", msg.getOperation().getStatusMessage());
+        assertTrue(msg.getOperation().isFailed());
+    }
+
+    /**
+     * Any HTTP status not in UpnpResponse.Status (here: a deliberately
+     * fictitious 418) must not throw and must produce a synthetic failed
+     * response. This guards against future status codes the canonical enum
+     * does not yet know about (issue #232 explicitly argues against the
+     * whack-a-mole alternative of expanding the enum one code at a time).
+     */
+    @Test
+    public void testCreateResponse_418_unmappedDoesNotThrow() throws Exception {
+        StreamResponseMessage msg = new HttpRequestSender().createResponse(buildResponse(418, "I'm a teapot"));
+        assertNotNull(msg);
+        assertEquals(418, msg.getOperation().getStatusCode());
+        assertEquals("HTTP 418", msg.getOperation().getStatusMessage());
+        assertTrue(msg.getOperation().isFailed());
+    }
+
+    private static BasicClassicHttpResponse buildResponse(int statusCode, String body) {
+        BasicClassicHttpResponse response = new BasicClassicHttpResponse(statusCode);
+        byte[] bytes = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
+        response.setEntity(new ByteArrayEntity(bytes, ContentType.TEXT_PLAIN));
+        return response;
     }
 }


### PR DESCRIPTION
## Summary

Fixes #232. YAACC was crash-looping when SSDP discovered any UPnP device whose
description endpoint returned an HTTP status not in `UpnpResponse.Status` (e.g.
HTTP 401 from a Sky Q DVR's authenticated UPnP service). Same bug class as #219
/ PR #221 (which fixed only HTTP 503 by adding it to the enum).

## Approach

This PR takes the broader fix instead of expanding the enum further:

1. `HttpRequestSender.createResponse` - synthesise a `UpnpResponse` for unmapped
   status codes instead of throwing `IllegalStateException`. The synthesised
   response uses the raw status code and a generic `HTTP <n>` message. Caller
   path (`RetrieveRemoteDescriptors.describe`) already treats `isFailed()`
   responses as a per-device skip.

2. `RetrieveRemoteDescriptors.describe` - extend the existing
   `IOException` / `IllegalArgumentException` catch ladder to also swallow
   `RuntimeException`, so any future unexpected runtime failure from a single
   device cannot kill the discovery worker.

## Testing

- New unit tests in `HttpRequestSenderTest` covering 200, 401, 418, 503 - all
  pass (`./gradlew :yaacc:testDebugUnitTest`: 6/6 in this suite, full test
  task BUILD SUCCESSFUL).
- `./gradlew :yaacc:assembleDebug` clean.
- Manual: installed debug APK on a Pixel 10a (Android 16) on a network containing
  a Sky Q ES140 DVR at `192.168.0.30:49153` (the device whose 401 reproduces the
  crash). Pre-fix: tight crash loop, fresh PIDs every ~5s. Post-fix: launched
  YAACC, ran for 5+ minutes, single PID stable, zero new entries in
  `dumpsys dropbox` for the fixed `versionCode=50101`, no FATAL/AndroidRuntime
  in logcat. Other UPnP devices on the LAN (LG OLED, Sky Hub, Chromecast Ultra)
  enumerate normally.

## Notes

The discovery-side `RuntimeException` catch is intentionally broad. The current
catch ladder covers `IllegalArgumentException` and `IOException`; both PR #221
(503) and this PR (401) demonstrate that the cling library has additional throw
sites for runtime exceptions that escape the worker thread. Catching
`RuntimeException` at the worker boundary is a defence-in-depth measure - a
single misbehaving device on the LAN should never be able to kill the app.

The alternative of adding 401, 403, 410, 429, 451, 502, 504, 511, ... to the
canonical `UpnpResponse.Status` enum would defeat its purpose (labelling the
UPnP-relevant statuses) and would still leave the next unknown status as a
crash. The `UpnpResponse(int, String)` constructor is exactly designed for the
case where there is no canonical mapping.

Made with [Cursor](https://cursor.com)